### PR TITLE
Two step deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The pretrained model ([Mobilenet V2](https://pytorch.org/hub/pytorch_vision_mobi
 
 #### 2.C The `deployment` step
 
-Run the `push` step as follows
+Run the `deploy` step as follows
 
 ```shell
 bash pipeline.sh -s <stage> -d <path>

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ where `<stage>` refers to the development stage (i.e. `dev`, `stage`, `prod`).
 
 ___
 
-### 2. Pushing the Docker Image to ECR Registry
+### 2. Deploying the Pytorch Model
 
 > **TL: DR** \
 > On your terminal run 
->>> `bash pipeline.sh -s <stage> -p ./pytorch-example`
+>>> `bash pipeline.sh -s <stage> -d ./pytorch-example`
 
 #### 2.A The Dockerfile
  
@@ -69,12 +69,12 @@ This base image must implement the Lambda Runtime API `awslambdaric`, the [docs]
 
 The pretrained model ([Mobilenet V2](https://pytorch.org/hub/pytorch_vision_mobilenet_v2/)) is loaded from the `function` directory of the container. Optionally you can use [boto3](https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3-example-download-file.html) to retrieve the model from an `S3` bucket.
 
-#### 2.C The `push` step
+#### 2.C The `deployment` step
 
 Run the `push` step as follows
 
 ```shell
-bash pipeline.sh -s <stage> -p <path>
+bash pipeline.sh -s <stage> -d <path>
 ```
 
 where the `<path>` argument (defaults to current paht) refers to the directory where the `Dockerfile` and the `app` is located
@@ -82,29 +82,12 @@ where the `<path>` argument (defaults to current paht) refers to the directory w
 For instance,
  
 ```shell
-bash pipeline.sh -s dev -p ./pytorch-example
+bash pipeline.sh -s dev -d ./pytorch-example
 ```
 
 
-> **Note**: This will fail if you have not already run the `-r` flag in the `pipeline.sh`. Alternatively you can run them together: `bash pipeline.sh -s <stage> -r -p <path>`
+> **Note **: This will fail if you have not already run the `-r` flag in the `pipeline.sh`. Alternatively you can run them together: `bash pipeline.sh -s <stage> -r -d <path>`
 
-___
-
-### 3. Provision a Serverless Lambda Function
-
-Launch the deployment step
-
-```shell
-bash pipeline.sh -s <stage> -d
-```
-
-For instance, 
-
-```shell
-bash pipeline.sh -s dev -d
-```
-
-> **Note**: If you have not previous run any step, execute `bash pipeline.sh -s <stage> -r -p <path> -d`
 ___
 
 ### 4. Get Predictions
@@ -161,7 +144,7 @@ export PREFIX_LAMBDA="sam_templates/xgboost-lambda-example"
 and run 
 
 ```shell
-bash pipeline.sh -s <stage> -r -p ./xgboost-example -d
+bash pipeline.sh -s <stage> -r -d ./xgboost-example
 ```
 
 where `<stage>` refers to the development stage (i.e. `dev`, `stage`, `prod`). If you want to run each step at a time, refer to the Pytorch example for an explanation of each step.

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Remember to export the following ENV variables:
-export CAPABILITIES="CAPABILITY_NAMED_IAM"
-export PREFIX_LAMBDA="sam_templates/pytorch-lambda-l"
-export TEMPLATE_LAMBDA="pytorch-lambda-l"
-export TEMPLATE_REGISTRY="pytorch-example-l"
+# export CAPABILITIES="CAPABILITY_NAMED_IAM"
+# export PREFIX_LAMBDA="sam_templates/pytorch-lambda-l"
+# export TEMPLATE_LAMBDA="pytorch-lambda-l"
+# export TEMPLATE_REGISTRY="pytorch-example-l"
 
 account=$(aws sts get-caller-identity --query Account --output text)
 user=$(aws iam get-user --query User.UserName --output text)

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Remember to export the following ENV variables:
-# export CAPABILITIES="CAPABILITY_NAMED_IAM"
-# export PREFIX_LAMBDA="sam_templates/pytorch-lambda"
-# export TEMPLATE_LAMBDA="pytorch-lambda"
-# export TEMPLATE_REGISTRY="pytorch-example"
+export CAPABILITIES="CAPABILITY_NAMED_IAM"
+export PREFIX_LAMBDA="sam_templates/pytorch-lambda-l"
+export TEMPLATE_LAMBDA="pytorch-lambda-l"
+export TEMPLATE_REGISTRY="pytorch-example-l"
 
 account=$(aws sts get-caller-identity --query Account --output text)
 user=$(aws iam get-user --query User.UserName --output text)
@@ -13,7 +13,7 @@ region=${region:-us-west-2} # region defaults to us-west-2 if not defined
 DOCKER_REGISTRY="${account}.dkr.ecr.${region}.amazonaws.com"
 
 
-while getopts ":s::rd" OPTION
+while getopts ":s:rd:" OPTION
 do
 	case $OPTION in
         s)
@@ -32,7 +32,7 @@ do
             echo "Retrieve Bucket Name"
             export BUCKET=$(aws cloudformation --region "${region}" describe-stacks --stack-name "$TEMPLATE_REGISTRY" --query "Stacks[0].Outputs[0].OutputValue")
             echo "Building template"
-            sam build -t template.yaml --parameter-overrides DockerPath=${path}
+            sam build -t template.yaml --parameter-overrides DockerPath="${path}"
             echo "Deploying template"
             sam deploy --stack-name ${TEMPLATE_LAMBDA} --capabilities "CAPABILITY_NAMED_IAM" --parameter-overrides Project="${TEMPLATE_LAMBDA}" Stage=${stage} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --region "${region}" --image-repository "${DOCKER_REGISTRY}/${APP_NAME//\"}" --force-upload --no-confirm-changeset
             ;;

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -13,7 +13,7 @@ region=${region:-us-west-2} # region defaults to us-west-2 if not defined
 DOCKER_REGISTRY="${account}.dkr.ecr.${region}.amazonaws.com"
 
 
-while getopts ":s:p:rd" OPTION
+while getopts ":s:rd" OPTION
 do
 	case $OPTION in
         s)
@@ -24,25 +24,17 @@ do
 			echo "Deploying CFN Template in stage ${stage}"
             sam deploy -t registry.yaml --stack-name ${TEMPLATE_REGISTRY} --capabilities ${CAPABILITIES} --parameter-overrides Project=${TEMPLATE_REGISTRY} Stage=${stage} User=${user} --force-upload --no-confirm-changeset
 			;;
-		p)
-            path=$OPTARG
-            path=${path:-.} # path defaults to current path if not defined
-		    echo "Retrieve Repository Name"
-            export APP_NAME=$(aws cloudformation --region "${region}" describe-stacks --stack-name "$TEMPLATE_REGISTRY" --query "Stacks[0].Outputs[1].OutputValue")
-            echo "$APP_NAME"
-            echo "Logging to ECR"
-            aws ecr get-login-password | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
-            docker build -t $DOCKER_REGISTRY/${APP_NAME//\"}:latest ${path}
-            docker push $DOCKER_REGISTRY/${APP_NAME//\"}:latest
-			;;
         d)
+            path=$OPTARG
+            path=${path:-.}
             echo "Retrieve Repository Name"
             export APP_NAME=$(aws cloudformation --region "${region}" describe-stacks --stack-name "$TEMPLATE_REGISTRY" --query "Stacks[0].Outputs[1].OutputValue")
             echo "Retrieve Bucket Name"
             export BUCKET=$(aws cloudformation --region "${region}" describe-stacks --stack-name "$TEMPLATE_REGISTRY" --query "Stacks[0].Outputs[0].OutputValue")
-            echo "$APP_NAME"
             echo "Building template"
-            sam deploy -t template.yaml --stack-name ${TEMPLATE_LAMBDA} --capabilities ${CAPABILITIES} --parameter-overrides Project=${TEMPLATE_REGISTRY} Repository=${APP_NAME//\"} Stage=${stage} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --force-upload --no-confirm-changeset
+            sam build -t template.yaml
+            echo "Deploying template"
+            sam deploy --stack-name ${TEMPLATE_LAMBDA} --capabilities "CAPABILITY_NAMED_IAM" --parameter-overrides Project="${TEMPLATE_LAMBDA}" Stage=${stage} DockerPath=${path} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --region "${region}" --image-repository "${DOCKER_REGISTRY}/${APP_NAME//\"}" --force-upload --no-confirm-changeset
             ;;
         \?)
             echo "Usage: pipeline.sh [-s] <stage> [-r] [-p] <path> [-d]"

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -32,9 +32,9 @@ do
             echo "Retrieve Bucket Name"
             export BUCKET=$(aws cloudformation --region "${region}" describe-stacks --stack-name "$TEMPLATE_REGISTRY" --query "Stacks[0].Outputs[0].OutputValue")
             echo "Building template"
-            sam build -t template.yaml
+            sam build -t template.yaml --parameter-overrides DockerPath=${path}
             echo "Deploying template"
-            sam deploy --stack-name ${TEMPLATE_LAMBDA} --capabilities "CAPABILITY_NAMED_IAM" --parameter-overrides Project="${TEMPLATE_LAMBDA}" Stage=${stage} DockerPath=${path} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --region "${region}" --image-repository "${DOCKER_REGISTRY}/${APP_NAME//\"}" --force-upload --no-confirm-changeset
+            sam deploy --stack-name ${TEMPLATE_LAMBDA} --capabilities "CAPABILITY_NAMED_IAM" --parameter-overrides Project="${TEMPLATE_LAMBDA}" Stage=${stage} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --region "${region}" --image-repository "${DOCKER_REGISTRY}/${APP_NAME//\"}" --force-upload --no-confirm-changeset
             ;;
         \?)
             echo "Usage: pipeline.sh [-s] <stage> [-r] [-d] <path>"

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -13,7 +13,7 @@ region=${region:-us-west-2} # region defaults to us-west-2 if not defined
 DOCKER_REGISTRY="${account}.dkr.ecr.${region}.amazonaws.com"
 
 
-while getopts ":s:rd" OPTION
+while getopts ":s::rd" OPTION
 do
 	case $OPTION in
         s)
@@ -37,7 +37,7 @@ do
             sam deploy --stack-name ${TEMPLATE_LAMBDA} --capabilities "CAPABILITY_NAMED_IAM" --parameter-overrides Project="${TEMPLATE_LAMBDA}" Stage=${stage} DockerPath=${path} --s3-bucket ${BUCKET//\"} --s3-prefix ${PREFIX_LAMBDA} --region "${region}" --image-repository "${DOCKER_REGISTRY}/${APP_NAME//\"}" --force-upload --no-confirm-changeset
             ;;
         \?)
-            echo "Usage: pipeline.sh [-s] <stage> [-r] [-p] <path> [-d]"
+            echo "Usage: pipeline.sh [-s] <stage> [-r] [-d] <path>"
             exit 1
             ;;
 	esac

--- a/template.yaml
+++ b/template.yaml
@@ -16,9 +16,9 @@ Parameters:
   Project: 
     Type: String
     Default: 'docker-image-test'
-  Repository:
+  DockerPath:
     Type: String
-    Default: 'ecr-repository'
+    Default: './pytorch-example'
 
 
 Globals:
@@ -31,7 +31,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub '${Project}-${Stage}'
-      ImageUri: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}:latest'
       PackageType: Image
       Events:
         HelloWorld:
@@ -39,6 +38,10 @@ Resources:
           Properties:
             Path: /myexample # Replace this for most descriptive path
             Method: post
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: !Sub '{DockerPath}'
+      DockerTag: 'latest'
     Tags: 
       version: !Ref Version
       stage: !Ref Stage
@@ -47,5 +50,5 @@ Resources:
 
 Outputs:
   MyCustomDockerApi:
-    Description: 'API Gateway Prod endpoint URL for My Custom Docker function'
-    Value: !Sub 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/myexample/'
+    Description: 'API Gateway Prod endpoint URL for My Docker Lambda function'
+    Value: !Sub 'https://${MyDockerLambda}.execute-api.${AWS::Region}.amazonaws.com/Prod/myexample/'

--- a/template.yaml
+++ b/template.yaml
@@ -40,7 +40,7 @@ Resources:
             Method: post
     Metadata:
       Dockerfile: Dockerfile
-      DockerContext: !Sub '{DockerPath}'
+      DockerContext: !Sub '${DockerPath}'
       DockerTag: 'latest'
     Tags: 
       version: !Ref Version


### PR DESCRIPTION
This branch develops a two step deploy using the `Metadata` property of the resource `AWS::Serverless::Lambda`. 

Modified files: 

* `template.yaml`. Read the dockerfile from metadata
* `pipeline.sh`. Two step deploy
       1.  Pass a path argument to `-d` stage to read the Dockerfile.
       2. Remove `push` step, build docker image with `sam build`.
* `README.md`. Explain two step deployment